### PR TITLE
Top Safariでアイコン画像が縦伸びする点の修正、SNSボタン調整

### DIFF
--- a/TibaSite/TibaSite/ClientApp/src/components/Home.css
+++ b/TibaSite/TibaSite/ClientApp/src/components/Home.css
@@ -396,12 +396,36 @@ text-shadow: 1px 0 0 black, 0 1px 0 black, -1px 0 0 black, 0 -1px 0 black;
     background-color: rgb(33 192 253 / 95%);
     color: #fff;
     border-color: #343a40;
+    transition: .3s background-color;
+}
+.btn-twitter i{
+    transition: .3s transform;
+}
+.btn-twitter:hover {
+    background-color: rgb(33 192 253 / 80%);
+    color: #fff;
+    text-decoration: none;
+}
+.btn-twitter:hover i.fas{
+    transform:translateX(25%);
 }
 
 .btn-youtube {
     background-color: rgb(233 75 75 / 95%);
     color: #fff;
     border-color: #343a40;
+    transition: .3s background-color;
+}
+.btn-youtube i{
+    transition: .3s transform;
+}
+.btn-youtube:hover {
+    background-color: rgb(233 75 75 / 80%);
+    color: #fff;
+    text-decoration: none;
+}
+.btn-youtube:hover i.fas{
+    transform:translateX(25%);
 }
 
 .title {

--- a/TibaSite/TibaSite/ClientApp/src/components/Home.js
+++ b/TibaSite/TibaSite/ClientApp/src/components/Home.js
@@ -50,12 +50,12 @@ export class Home extends Component {
 								<div className="row mt-2">
 									<div className="col-md-7">
 										<a href="https://twitter.com/NeetTiba_Vtuber" className="btn-twitter btn-block btn-lg mb-3 font-weight-bold p-3" role="button" aria-pressed="true">
-											twitter<i className="fas fa-arrow-right ml-3"></i>
+											<i className="fab fa-twitter mr-2"></i>Twitter<i className="fas fa-arrow-right ml-3"></i>
 										</a>
 									</div>
 									<div className="col-md-5">
 										<a href="https://www.youtube.com/channel/UCxV7tp_Yn-I4HxdIelt2JqA" className="btn-youtube btn-block btn-lg font-weight-bold p-3" role="button" aria-pressed="true">
-											Youtube<i className="fas fa-arrow-right ml-3"></i>
+											<i className="fab fa-youtube mr-2"></i>Youtube<i className="fas fa-arrow-right ml-3"></i>
 										</a>
 									</div>
 								</div>

--- a/TibaSite/TibaSite/ClientApp/src/components/Home.js
+++ b/TibaSite/TibaSite/ClientApp/src/components/Home.js
@@ -31,7 +31,7 @@ export class Home extends Component {
 					<div className="container py-5">
 						<div className="row mb-5">
 							<div className="col-md-6 mb-3">
-								<img src={require('../media/img/boss1.png')} alt="boss" className="img-fluid h-100" />
+								<img src={require('../media/img/boss1.png')} alt="boss" className="img-fluid" />
 							</div>
 							<div className="col-md-6">
 								<h3 className="text-center font-weight-bold mb-3">代表挨拶</h3>


### PR DESCRIPTION
①サイトTOPをSafari(Mac,iPhone)で閲覧したときに代表あいさつの画像が縦に伸びる点を修正しました。
https://gyazo.com/bf849c2490a227f1771a091ebc8f1efb

②代表あいさつの下にあるSNSボタンの調整
SNSボタンにアイコンを追加、マウスホバー時に背景色が少し変わる&矢印アイコンが右に動くアニメーションを追加しました。

ご確認よろしくおねがいします！